### PR TITLE
Added shared pre-commit hooks config

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+---
+# shared pre-commit hooks
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+  - repo: https://github.com/python/black.git
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v3.2.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: check-byte-order-marker
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: debug-statements
+        language_version: python3
+  - repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - pydocstyle>=5.1.1
+          - flake8-absolute-import
+          - flake8-black>=0.1.1
+          - flake8-docstrings>=1.5.0
+        language_version: python3
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.25.0
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.790
+    hooks:
+      - id: mypy
+        # empty args needed in order to match mypy cli behavior
+        # args: []
+        # entry: mypy molecule/
+        # pass_filenames: false
+    # mypy is riky due to missing project specific dependencies
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v2.6.0
+    hooks:
+      - id: pylint
+    # pylint is riky due to missing project specific dependencies

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: shared-hooks
+  name: shared-hooks
+  language: script
+  entry: ./run-shared-hooks
+  verbose: true

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,18 @@
+extends: default
+ignore: |
+  .tox
+  # HACK: https://github.com/pyupio/pyup/issues/346
+  .pyup.yml
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  document-start: disable
+  line-length: disable
+  # https://github.com/adrienverge/yamllint/issues/141
+  comments-indentation: disable
+  truthy:
+    allowed-values: ['true', 'false', 'on']

--- a/run-shared-hooks
+++ b/run-shared-hooks
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# pylint: disable=invalid-name
+"""Meta hook that calls shared hooks."""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+
+
+def main():
+    """Execute pre-commmit using shared hook config."""
+    cfg = os.path.join(HERE, ".pre-commit-config.yaml")
+    cmd = ["pre-commit", "run", "--config", cfg, "--files"] + sys.argv[1:]
+    os.execvp(cmd[0], cmd)
+
+
+if __name__ == "__main__":
+    exit(main())  # pylint: disable=consider-using-sys-exit


### PR DESCRIPTION
* enables pre-commit hooks on this repo
* allows other repositories to re-use all hooks from this repository in order to about having to maintain them. The risk is that a bump of shared hooks could break CI on consumers, for good reasons, or not.